### PR TITLE
Updated to babel 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,15 @@
     "extract-text-webpack-plugin": "^3.0.2",
     "node-sass": "^4.9.2",
     "react-app-rewire-hot-loader": "^1.0.1",
-    "sass-loader": "^7.0.3"
+    "sass-loader": "^7.0.3",
+    "react": "^16.0.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-jest": "^23.4.0",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-env": "^1.7.0"
+    "@babel/cli": "^7.1.2",
+    "babel-jest": "^23.6.0",
+    "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+    "@babel/preset-env": "^7.1.0",
+    "@babel/core": "^7.0.0",
+    "react-hot-loader": "^4.0.0"
   }
 }


### PR DESCRIPTION
## Summary

**Note**: We should hold this merge until we're sure everything works with the actual version, in order to iterate it with this changes.

- Updated to Babel 7
- Fixed some dependency warnings

## Known Issues

The following are two warnings I didn't solve:

```
npm WARN ajv-keywords@3.2.0 requires a peer of ajv@^6.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN babel-jest@23.6.0 requires a peer of babel-core@^6.0.0 || ^7.0.0-0 but none is installed. You must install peer dependencies yourself.
```

The first one seems to be a bug with my version of npm (https://stackoverflow.com/questions/50320193/ajv-keywords3-2-0-requires-a-peer-of-ajv6-0-0)
The second I didn't want to fix on purpose, I want to see if jest works with a higher babel version than specified